### PR TITLE
Fonction removeShape  : vérifie que la liste n'est pas vide

### DIFF
--- a/src/js/Draw/shapeDraw.js
+++ b/src/js/Draw/shapeDraw.js
@@ -91,18 +91,20 @@ function DragShapeSilouette(event) {
 }
 
 function removeShape() {
-    // Récupérer la div parent
-    const div = document.querySelector('.shape-contenaire');
+    if (listeShape.length > 0) {
+        // Récupérer la div parent
+        const div = document.querySelector('.shape-contenaire');
 
-    // Supprimer la div parent
-    canvas.removeChild(div);
+        // Supprimer la div parent
+        canvas.removeChild(div);
 
-    // Supprimer la forme de la liste des formes
-    listeShape.pop();
+        // Supprimer la forme de la liste des formes
+        listeShape.pop();
 
-    console.log(listeShape);
-
+        console.log(listeShape);
+    }
 }
+
 
 function startDrawingMode() {
     console.log(listeShape);


### PR DESCRIPTION
Je tente ici de répondre à ta question dans le fil "Problème list Electron" sur le serveur Codeur Pro. 


P'etre que c'est parce que quand t'ajoute une forme, elle va aussi dans la liste listeShape, quand t'appuie sur sur Ctrl+Z, tu dégages  la dernière forme de cette liste. Et du coup, si t'appuies deux fois sur le bouton controle Z ... cela va supprimer plusieurs fois la dernière forme de la liste.

Mais après je suis pas sur de bien avoir compris ton problème à 1000 % x) 

Pour résoudre ce problème, si c'est bien ca, il suffit de vérifier que la liste est pas vide avant de supprimer la forme. 